### PR TITLE
Fix/admin-table

### DIFF
--- a/src/app/(authenticated)/sindico/cadastros/administration/components/createAdmin.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/createAdmin.tsx
@@ -41,6 +41,7 @@ import unmask from "@/utils/unmask";
 import AddAptManager from "@/validations/admin/AddAptManager";
 
 import { AdminModalProps } from "./types";
+import { Timestamp } from "firebase/firestore";
 
 type AddAptManagerForm = z.infer<typeof AddAptManager>;
 const inputClassName = "border-[#DEE2E6] bg-[#F8F9FA]";
@@ -171,7 +172,9 @@ export default function CreateAdminModal({
         number: data.ownerAddressData.number,
         cep: unmask(data.ownerAddressData.cep),
         city: data.ownerAddressData.city,
-        status: Status.INACTIVE
+        status: Status.INACTIVE,
+        createdAt: Timestamp.now(),
+        blockedAt: null,
       };
 
       if (!adminData) {

--- a/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
@@ -1,58 +1,27 @@
+import { useState } from "react";
+
 import { ColumnDef } from "@tanstack/react-table";
 import { formatToCPF } from "brazilian-values";
 
 import { AptManagerEntity, Status } from "@/common/entities/aptManager";
+import Button from "@/components/atoms/Button/button";
 import Tag from "@/components/atoms/Tag/Tag";
-import { errorToast, successToast } from "@/hooks/useAppToast";
-import { queryClient } from "@/store/providers/queryClient";
-import { updateFirestoreDoc } from "@/store/services";
-import { activateUserAuth, deactivateUserAuth } from "@/store/services/auth";
+
+
+import AptManagerModal from "./createAdmin";
 
 const GetStatus = ({ data }: { data: AptManagerEntity }) => {
-  const handleUpdate = async () => {
-    const curStatus = data.status;
-    let nextStatus =
-      curStatus === Status.ACTIVE
-        ? Status.INACTIVE
-        : curStatus === Status.INACTIVE
-          ? Status.ACTIVE
-          : Status.UNDEFINED;
-    if (curStatus === Status.UNDEFINED) {
-      nextStatus = Status.ACTIVE;
-    }
-    const { error } = await updateFirestoreDoc<AptManagerEntity>({
-      documentPath: `/users/${data.id}`,
-      data: { status: nextStatus },
-    });
-
-    if (curStatus === Status.ACTIVE && nextStatus === Status.INACTIVE) {
-      const { error } = await deactivateUserAuth(data.id);
-      return error;
-    } else if (curStatus === Status.INACTIVE && nextStatus === Status.ACTIVE) {
-      const { error } = await activateUserAuth(data.id);
-      return error;
-    }
-
-    if (error) {
-      return errorToast("Erro ao atualizar o status do adminstrador");
-    }
-
-    successToast("Status do adminstrador atualizado com sucesso");
-    queryClient.invalidateQueries(["users", data.id]);
-  };
-
   return (
     <Tag
       variant={
         data.status === Status.ACTIVE
           ? "greenBlack"
           : data.status === Status.INACTIVE
-            ? "red"
-            : "yellowBlack"
+          ? "red"
+          : "yellowBlack"
       }
       size="smLarge"
-      onClick={handleUpdate}
-      className="cursor-pointer transition-transform hover:scale-105"
+      className="transition-transform"
     >
       {data.status
         ? data.status.charAt(0).toUpperCase() +
@@ -66,22 +35,22 @@ export const columns: ColumnDef<AptManagerEntity>[] = [
   { header: "Cargo", accessorKey: "adminRole" },
   {
     header: "Nome",
-    accessorKey: "name",
+    accessorKey: "name"
   },
   {
     header: "CPF",
     accessorKey: "cpf",
     cell: ({ row }) =>
-      row.original.cpf ? formatToCPF(row.original.cpf) : "Sem dados",
+      row.original.cpf ? formatToCPF(row.original.cpf) : "Sem dados"
   },
   {
     header: "Email",
-    accessorKey: "email",
+    accessorKey: "email"
   },
   {
     accessorKey: "month",
     header: "Status",
-    cell: ({ row }) => <GetStatus data={row.original} />,
+    cell: ({ row }) => <GetStatus data={row.original} />
   },
   {
     header: "Data de Início",

--- a/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
@@ -1,41 +1,14 @@
-// import { useState } from "react";
-
 import { useState } from "react";
 
 import { ColumnDef } from "@tanstack/react-table";
 import { formatToCPF } from "brazilian-values";
 
 import { AptManagerEntity, Status } from "@/common/entities/aptManager";
-import Button from "@/components/atoms/Button/button";
 import Tag from "@/components/atoms/Tag/Tag";
 import { errorToast, successToast } from "@/hooks/useAppToast";
 import { queryClient } from "@/store/providers/queryClient";
 import { updateFirestoreDoc } from "@/store/services";
 import { activateUserAuth, deactivateUserAuth } from "@/store/services/auth";
-
-import AptManagerModal from "./createAdmin";
-
-const Edit = ({ data }: { data: AptManagerEntity }) => {
-  const [modalOpen, setModalOpen] = useState(false);
-  return (
-    <>
-      <Button
-        variant={"outline-black"}
-        size="sm"
-        onClick={() => setModalOpen(true)}
-        className="rounded-sm text-[16px]"
-      >
-        Editar
-      </Button>
-
-      <AptManagerModal
-        isOpen={modalOpen}
-        onOpenChange={setModalOpen}
-        adminData={data}
-      />
-    </>
-  );
-};
 
 const GetStatus = ({ data }: { data: AptManagerEntity }) => {
   const handleUpdate = async () => {
@@ -51,7 +24,7 @@ const GetStatus = ({ data }: { data: AptManagerEntity }) => {
     }
     const { error } = await updateFirestoreDoc<AptManagerEntity>({
       documentPath: `/users/${data.id}`,
-      data: { status: nextStatus }
+      data: { status: nextStatus },
     });
 
     if (curStatus === Status.ACTIVE && nextStatus === Status.INACTIVE) {
@@ -95,26 +68,29 @@ export const columns: ColumnDef<AptManagerEntity>[] = [
   { header: "Cargo", accessorKey: "adminRole" },
   {
     header: "Nome",
-    accessorKey: "name"
+    accessorKey: "name",
   },
   {
     header: "CPF",
     accessorKey: "cpf",
     cell: ({ row }) =>
-      row.original.cpf ? formatToCPF(row.original.cpf) : "Sem dados"
+      row.original.cpf ? formatToCPF(row.original.cpf) : "Sem dados",
   },
   {
     header: "Email",
-    accessorKey: "email"
+    accessorKey: "email",
   },
   {
     accessorKey: "month",
     header: "Status",
-    cell: ({ row }) => <GetStatus data={row.original} />
+    cell: ({ row }) => <GetStatus data={row.original} />,
   },
   {
-    header: "Editar",
-    accessorKey: "Editar",
-    cell: ({ row }) => <Edit data={row.original} />
-  }
+    header: "Data de Início",
+    accessorKey: "startDate",
+  },
+  {
+    header: "Data de Bloqueio",
+    accessorKey: "blockDate",
+  },
 ];

--- a/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { timestampToDate } from "@/utils/timestampToDate";
 
 import { ColumnDef } from "@tanstack/react-table";
 import { formatToCPF } from "brazilian-values";
@@ -57,6 +58,13 @@ export const columns: ColumnDef<AptManagerEntity>[] = [
   {
     header: "Data de Início",
     accessorKey: "createdAt",
+    cell: ({ row }) => (
+      <p>
+        {row.original.createdAt
+          ? timestampToDate(row.original.createdAt).toLocaleDateString()
+          : ""}
+      </p>
+    )
   },
   {
     header: "Data de Bloqueio",

--- a/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
@@ -32,7 +32,9 @@ const GetStatus = ({ data }: { data: AptManagerEntity }) => {
 };
 
 export const columns: ColumnDef<AptManagerEntity>[] = [
-  { header: "Cargo", accessorKey: "adminRole" },
+  { 
+    header: "Cargo",
+    accessorKey: "adminRole" },
   {
     header: "Nome",
     accessorKey: "name"
@@ -48,16 +50,16 @@ export const columns: ColumnDef<AptManagerEntity>[] = [
     accessorKey: "email"
   },
   {
-    accessorKey: "month",
     header: "Status",
+    accessorKey: "month",
     cell: ({ row }) => <GetStatus data={row.original} />
   },
   {
     header: "Data de Início",
-    accessorKey: "startDate",
+    accessorKey: "createdAt",
   },
   {
     header: "Data de Bloqueio",
-    accessorKey: "blockDate",
+    accessorKey: "blockedAt",
   },
 ];

--- a/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import { ColumnDef } from "@tanstack/react-table";
 import { formatToCPF } from "brazilian-values";
 

--- a/src/app/(authenticated)/sindico/cadastros/administration/page.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/page.tsx
@@ -26,6 +26,7 @@ import { sendEmail } from "@/store/services/email";
 import { storageGet } from "@/store/services/storage";
 import unmask from "@/utils/unmask";
 import AddAptManagerSchema from "@/validations/admin/AddAptManager";
+import { Timestamp } from "firebase/firestore";
 
 type AddAptManagerForm = z.infer<typeof AddAptManagerSchema>;
 
@@ -103,7 +104,9 @@ const NovoSindico = () => {
       cep: unmask(data.ownerAddressData.cep),
       city: data.ownerAddressData.city,
       image: "",
-      status: Status.INACTIVE
+      status: Status.INACTIVE,
+      createdAt: Timestamp.fromDate(new Date()),
+      blockedAt: null,
     };
 
     await setFirestoreDoc<AptManagerEntity>({

--- a/src/app/admin/nova-empresa/page.tsx
+++ b/src/app/admin/nova-empresa/page.tsx
@@ -232,7 +232,7 @@ const NewCompany = () => {
 
       await setFirestoreDoc<AptManagerEntity>({
         docPath: `users/${aptManagerId}`,
-        data: { ...aptManagerData, image: imageUrl }
+        data: { ...aptManagerData, image: imageUrl, createdAt: Timestamp.now(), blockedAt: null }
       });
 
       const companyData = {

--- a/src/common/entities/aptManager.ts
+++ b/src/common/entities/aptManager.ts
@@ -22,6 +22,6 @@ export interface AptManagerEntity extends AddressFields {
   adminRole: string;
   maritalStatus: MaritalStatusOptionsType;
   status: Status;
-  startDate: string;
-  blockDate: string;
+  createdAt: string;
+  blockedAt: string;
 }

--- a/src/common/entities/aptManager.ts
+++ b/src/common/entities/aptManager.ts
@@ -1,3 +1,4 @@
+import { Timestamp } from "firebase/firestore";
 import { AddressFields } from "./adressFields";
 import { MaritalStatusOptionsType } from "./common/maritalStatusOptionsType";
 
@@ -22,6 +23,6 @@ export interface AptManagerEntity extends AddressFields {
   adminRole: string;
   maritalStatus: MaritalStatusOptionsType;
   status: Status;
-  createdAt: string;
-  blockedAt: string;
+  createdAt: Timestamp;
+  blockedAt: Timestamp | null;  
 }

--- a/src/common/entities/aptManager.ts
+++ b/src/common/entities/aptManager.ts
@@ -4,7 +4,7 @@ import { MaritalStatusOptionsType } from "./common/maritalStatusOptionsType";
 export enum Status {
   ACTIVE = "ativo",
   INACTIVE = "inativo",
-  UNDEFINED = "indefinido"
+  UNDEFINED = "indefinido",
 }
 
 export interface AptManagerEntity extends AddressFields {
@@ -22,4 +22,6 @@ export interface AptManagerEntity extends AddressFields {
   adminRole: string;
   maritalStatus: MaritalStatusOptionsType;
   status: Status;
+  startDate: string;
+  blockDate: string;
 }


### PR DESCRIPTION
 # Added columns to the AptManagersTable component:
* createdAt
* blockedAt
 # Removed:
* Administrator Edit column
* Edit function
 # Edited the GetStatus function:
* Now the manager can only view the status, not edit it.
 # How to test
Open the terminal and go to the folder of this project.

In terminal:

git checkout main
git pull
git checkout <fix/admin-table>
git pull origin <fix/admin-table>
pnpm install
pnpm run dev
In your browser, go to http://localhost:3000/.

Check if the changes in the AptManagersTable component are correct:

Log in as the manager
Go to the registration screen
Verify the new columns: Start Date and Block Date.
Confirm that the Administrator Edit column and Edit function are no longer present.
Ensure the manager can view, but not edit, the status.
Read the "changed files" section on GitHub.

Test any related functionalities or scenarios you consider necessary.