### PR TITLE
feature/columns-date-get-status

### DIFF
--- a/src/app/(authenticated)/sindico/cadastros/administration/components/createAdmin.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/createAdmin.tsx
@@ -4,6 +4,7 @@ import { useState, useRef } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { isCPF } from "brazilian-values";
+import { Timestamp } from "firebase/firestore";
 import { Camera } from "lucide-react";
 import Image from "next/image";
 import { useForm, SubmitHandler } from "react-hook-form";
@@ -171,7 +172,9 @@ export default function CreateAdminModal({
         number: data.ownerAddressData.number,
         cep: unmask(data.ownerAddressData.cep),
         city: data.ownerAddressData.city,
-        status: Status.INACTIVE
+        status: Status.INACTIVE,
+        createdAt: Timestamp.now(),
+        blockedAt: null
       };
 
       if (!adminData) {

--- a/src/app/(authenticated)/sindico/cadastros/administration/components/createAdmin.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/createAdmin.tsx
@@ -93,7 +93,7 @@ export default function CreateAdminModal({
           maritalStatusOptions.find(
             (item) => item.label === adminData?.maritalStatus
           )?.value ?? "",
-        status: adminData?.status ?? Status.UNDEFINED
+        status: adminData?.status ?? Status.ACTIVE
       },
       ownerAddressData: {
         cep: adminData?.cep ?? "",

--- a/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
@@ -1,27 +1,82 @@
+import { useState, useEffect } from "react";
+
 import { ColumnDef } from "@tanstack/react-table";
 import { formatToCPF } from "brazilian-values";
+import { Timestamp } from "firebase/firestore";
 
 import { AptManagerEntity, Status } from "@/common/entities/aptManager";
 import Tag from "@/components/atoms/Tag/Tag";
-import { timestampToDate } from "@/utils/timestampToDate";
+import { errorToast, successToast } from "@/hooks/useAppToast";
+import { queryClient } from "@/store/providers/queryClient";
+import { updateFirestoreDoc } from "@/store/services";
+import { activateUserAuth, deactivateUserAuth } from "@/store/services/auth";
 
 const GetStatus = ({ data }: { data: AptManagerEntity }) => {
+  const [loading, setLoading] = useState(false);
+  const [optimisticStatus, setOptimisticStatus] = useState<string | undefined>(
+    data.status
+  );
+
+  useEffect(() => {
+    setOptimisticStatus(data.status);
+  }, [data.status]);
+
+  const handleUpdate = async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const curStatus = optimisticStatus;
+      const nextStatus =
+        curStatus === Status.ACTIVE ? Status.INACTIVE : Status.ACTIVE;
+      const blockedAt = nextStatus === Status.INACTIVE ? Timestamp.now() : null;
+      setOptimisticStatus(nextStatus);
+      await updateFirestoreDoc<AptManagerEntity>({
+        documentPath: `/users/${data.id}`,
+        data: {
+          status: nextStatus,
+          blockedAt
+        }
+      });
+      if (curStatus === Status.ACTIVE) {
+        await deactivateUserAuth(data.id);
+      } else {
+        await activateUserAuth(data.id);
+      }
+      await queryClient.invalidateQueries(["users", data.id]);
+      successToast("Status do administrador atualizado com sucesso");
+    } catch (error) {
+      setOptimisticStatus(data.status);
+      errorToast(
+        error instanceof Error
+          ? error.message
+          : "Erro ao atualizar o status do administrador"
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <Tag
       variant={
-        data.status === Status.ACTIVE
+        optimisticStatus === Status.ACTIVE
           ? "greenBlack"
-          : data.status === Status.INACTIVE
+          : optimisticStatus === Status.INACTIVE
             ? "red"
             : "yellowBlack"
       }
       size="smLarge"
-      className="transition-transform"
+      onClick={handleUpdate}
+      className={`cursor-pointer transition-transform hover:scale-105 ${
+        loading ? "cursor-not-allowed opacity-50" : ""
+      }`}
     >
-      {data.status
-        ? data.status.charAt(0).toUpperCase() +
-          data.status.slice(1).toLowerCase()
-        : "Indefinido"}
+      {loading
+        ? "Atualizando..."
+        : optimisticStatus
+          ? optimisticStatus.charAt(0).toUpperCase() +
+            optimisticStatus.slice(1).toLowerCase()
+          : "Indefinido"}
     </Tag>
   );
 };
@@ -53,16 +108,27 @@ export const columns: ColumnDef<AptManagerEntity>[] = [
   {
     header: "Data de Início",
     accessorKey: "createdAt",
-    cell: ({ row }) => (
-      <p>
-        {row.original.createdAt
-          ? timestampToDate(row.original.createdAt).toLocaleDateString()
-          : ""}
-      </p>
-    )
+    cell: ({ row }) => {
+      const createdAt = row.original.createdAt;
+      const date =
+        createdAt instanceof Timestamp
+          ? createdAt.toDate()
+          : new Date(createdAt);
+      return createdAt ? date.toLocaleDateString() : "Não disponível";
+    }
   },
   {
     header: "Data de Bloqueio",
-    accessorKey: "blockedAt"
+    accessorKey: "blockedAt",
+    cell: ({ row }) => {
+      const blockedAt = row.original.blockedAt;
+      const date =
+        blockedAt instanceof Timestamp
+          ? blockedAt.toDate()
+          : blockedAt
+            ? new Date(blockedAt)
+            : null;
+      return date ? date.toLocaleDateString() : "Não bloqueado";
+    }
   }
 ];

--- a/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
@@ -46,6 +46,11 @@ export const columns: ColumnDef<AptManagerEntity>[] = [
     accessorKey: "email"
   },
   {
+    header: "Status",
+    accessorKey: "month",
+    cell: ({ row }) => <GetStatus data={row.original} />
+  },
+  {
     header: "Data de Criação",
     accessorKey: "createdAt",
     cell: ({ row }) => {

--- a/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
@@ -40,15 +40,8 @@ const Edit = ({ data }: { data: AptManagerEntity }) => {
 const GetStatus = ({ data }: { data: AptManagerEntity }) => {
   const handleUpdate = async () => {
     const curStatus = data.status;
-    let nextStatus =
-      curStatus === Status.ACTIVE
-        ? Status.INACTIVE
-        : curStatus === Status.INACTIVE
-          ? Status.ACTIVE
-          : Status.UNDEFINED;
-    if (curStatus === Status.UNDEFINED) {
-      nextStatus = Status.ACTIVE;
-    }
+    const nextStatus =
+      curStatus === Status.ACTIVE ? Status.INACTIVE : Status.ACTIVE;
     const { error } = await updateFirestoreDoc<AptManagerEntity>({
       documentPath: `/users/${data.id}`,
       data: { status: nextStatus }

--- a/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/newAdminColumns.tsx
@@ -1,68 +1,11 @@
-// import { useState } from "react";
-
-import { useState } from "react";
-
 import { ColumnDef } from "@tanstack/react-table";
 import { formatToCPF } from "brazilian-values";
 
 import { AptManagerEntity, Status } from "@/common/entities/aptManager";
-import Button from "@/components/atoms/Button/button";
 import Tag from "@/components/atoms/Tag/Tag";
-import { errorToast, successToast } from "@/hooks/useAppToast";
-import { queryClient } from "@/store/providers/queryClient";
-import { updateFirestoreDoc } from "@/store/services";
-import { activateUserAuth, deactivateUserAuth } from "@/store/services/auth";
-
-import AptManagerModal from "./createAdmin";
-
-const Edit = ({ data }: { data: AptManagerEntity }) => {
-  const [modalOpen, setModalOpen] = useState(false);
-  return (
-    <>
-      <Button
-        variant={"outline-black"}
-        size="sm"
-        onClick={() => setModalOpen(true)}
-        className="rounded-sm text-[16px]"
-      >
-        Editar
-      </Button>
-
-      <AptManagerModal
-        isOpen={modalOpen}
-        onOpenChange={setModalOpen}
-        adminData={data}
-      />
-    </>
-  );
-};
+import { timestampToDate } from "@/utils/timestampToDate";
 
 const GetStatus = ({ data }: { data: AptManagerEntity }) => {
-  const handleUpdate = async () => {
-    const curStatus = data.status;
-    const nextStatus =
-      curStatus === Status.ACTIVE ? Status.INACTIVE : Status.ACTIVE;
-    const { error } = await updateFirestoreDoc<AptManagerEntity>({
-      documentPath: `/users/${data.id}`,
-      data: { status: nextStatus }
-    });
-
-    if (curStatus === Status.ACTIVE && nextStatus === Status.INACTIVE) {
-      const { error } = await deactivateUserAuth(data.id);
-      return error;
-    } else if (curStatus === Status.INACTIVE && nextStatus === Status.ACTIVE) {
-      const { error } = await activateUserAuth(data.id);
-      return error;
-    }
-
-    if (error) {
-      return errorToast("Erro ao atualizar o status do adminstrador");
-    }
-
-    successToast("Status do adminstrador atualizado com sucesso");
-    queryClient.invalidateQueries(["users", data.id]);
-  };
-
   return (
     <Tag
       variant={
@@ -73,8 +16,7 @@ const GetStatus = ({ data }: { data: AptManagerEntity }) => {
             : "yellowBlack"
       }
       size="smLarge"
-      onClick={handleUpdate}
-      className="cursor-pointer transition-transform hover:scale-105"
+      className="transition-transform"
     >
       {data.status
         ? data.status.charAt(0).toUpperCase() +
@@ -85,7 +27,10 @@ const GetStatus = ({ data }: { data: AptManagerEntity }) => {
 };
 
 export const columns: ColumnDef<AptManagerEntity>[] = [
-  { header: "Cargo", accessorKey: "adminRole" },
+  {
+    header: "Cargo",
+    accessorKey: "adminRole"
+  },
   {
     header: "Nome",
     accessorKey: "name"
@@ -101,13 +46,23 @@ export const columns: ColumnDef<AptManagerEntity>[] = [
     accessorKey: "email"
   },
   {
-    accessorKey: "month",
     header: "Status",
+    accessorKey: "month",
     cell: ({ row }) => <GetStatus data={row.original} />
   },
   {
-    header: "Editar",
-    accessorKey: "Editar",
-    cell: ({ row }) => <Edit data={row.original} />
+    header: "Data de Início",
+    accessorKey: "createdAt",
+    cell: ({ row }) => (
+      <p>
+        {row.original.createdAt
+          ? timestampToDate(row.original.createdAt).toLocaleDateString()
+          : ""}
+      </p>
+    )
+  },
+  {
+    header: "Data de Bloqueio",
+    accessorKey: "blockedAt"
   }
 ];

--- a/src/app/(authenticated)/sindico/cadastros/administration/page.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/page.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { isCPF } from "brazilian-values";
+import { Timestamp } from "firebase/firestore";
 import { useForm } from "react-hook-form";
 import { v4 as uuidV4 } from "uuid";
 import { z } from "zod";
@@ -103,7 +104,9 @@ const NovoSindico = () => {
       cep: unmask(data.ownerAddressData.cep),
       city: data.ownerAddressData.city,
       image: "",
-      status: Status.INACTIVE
+      status: Status.INACTIVE,
+      createdAt: Timestamp.now(),
+      blockedAt: null
     };
 
     await setFirestoreDoc<AptManagerEntity>({

--- a/src/app/(authenticated)/sindico/cadastros/administration/page.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/page.tsx
@@ -105,7 +105,7 @@ const NovoSindico = () => {
       city: data.ownerAddressData.city,
       image: "",
       status: Status.INACTIVE,
-      createdAt: Timestamp.now(),
+      createdAt: Timestamp.fromDate(new Date()),
       blockedAt: null
     };
 

--- a/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
+++ b/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
@@ -116,5 +116,21 @@ export const columns: ColumnDef<AptManagerEntity>[] = [
     header: "Editar",
     accessorKey: "Editar",
     cell: ({ row }) => <Edit data={row.original} />
+  },
+  {
+    header: "Data de Criação",
+    accessorKey: "createdAt",
+    cell: ({ row }) =>
+      row.original.createdAt
+        ? row.original.createdAt.toDate().toLocaleDateString() // Converte Timestamp para Date
+        : "Não disponível",
+  },
+  {
+    header: "Data de Bloqueio",
+    accessorKey: "blockedAt",
+    cell: ({ row }) =>
+      row.original.blockedAt
+        ? row.original.blockedAt.toDate().toLocaleDateString() // Converte Timestamp para Date
+        : "Não bloqueado",    
   }
 ];

--- a/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
+++ b/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
@@ -54,10 +54,14 @@ const GetStatus = ({ data }: { data: AptManagerEntity }) => {
       const curStatus = optimisticStatus;
       const nextStatus =
         curStatus === Status.ACTIVE ? Status.INACTIVE : Status.ACTIVE;
+      const blockedAt = nextStatus === Status.INACTIVE ? Timestamp.now() : null;
       setOptimisticStatus(nextStatus);
       await updateFirestoreDoc<AptManagerEntity>({
         documentPath: `/users/${data.id}`,
-        data: { status: nextStatus }
+        data: {
+          status: nextStatus,
+          blockedAt
+        }
       });
       if (curStatus === Status.ACTIVE) {
         await deactivateUserAuth(data.id);

--- a/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
+++ b/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
@@ -1,6 +1,6 @@
 // import { useState } from "react";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 import { ColumnDef } from "@tanstack/react-table";
 import { formatToCPF } from "brazilian-values";
@@ -39,7 +39,14 @@ const Edit = ({ data }: { data: AptManagerEntity }) => {
 
 const GetStatus = ({ data }: { data: AptManagerEntity }) => {
   const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState(data.status || Status.INACTIVE);
+  const [previousStatus, setPreviousStatus] = useState(data.status);
+
+  useEffect(() => {
+    if (previousStatus !== data.status) {
+      setLoading(false);
+      setPreviousStatus(data.status);
+    }
+  }, [data.status, previousStatus]);
 
   const handleUpdate = async () => {
     if (loading) return;
@@ -58,15 +65,13 @@ const GetStatus = ({ data }: { data: AptManagerEntity }) => {
         await activateUserAuth(data.id);
       }
       queryClient.invalidateQueries(["users", data.id]);
-      setStatus(nextStatus);
-      successToast("Status do administrador atualizado com sucesso");
+      successToast("Status do administrador está sendo atualizado");
     } catch (error) {
       errorToast(
         error instanceof Error
           ? error.message
           : "Erro ao atualizar o status do administrador"
       );
-    } finally {
       setLoading(false);
     }
   };
@@ -74,9 +79,9 @@ const GetStatus = ({ data }: { data: AptManagerEntity }) => {
   return (
     <Tag
       variant={
-        status === Status.ACTIVE
+        data.status === Status.ACTIVE
           ? "greenBlack"
-          : status === Status.INACTIVE
+          : data.status === Status.INACTIVE
             ? "red"
             : "yellowBlack"
       }
@@ -88,8 +93,9 @@ const GetStatus = ({ data }: { data: AptManagerEntity }) => {
     >
       {loading
         ? "Atualizando..."
-        : status
-          ? status.charAt(0).toUpperCase() + status.slice(1).toLowerCase()
+        : data.status
+          ? data.status.charAt(0).toUpperCase() +
+            data.status.slice(1).toLowerCase()
           : "Indefinido"}
     </Tag>
   );

--- a/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
+++ b/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
@@ -73,7 +73,6 @@ const GetStatus = ({ data }: { data: AptManagerEntity }) => {
           : "Erro ao atualizar o status do administrador"
       );
     } finally {
-      setOptimisticStatus(data.status);
       setLoading(false);
     }
   };

--- a/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
+++ b/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 
 import { ColumnDef } from "@tanstack/react-table";
 import { formatToCPF } from "brazilian-values";
+import { Timestamp } from "firebase/firestore";
 
 import { AptManagerEntity, Status } from "@/common/entities/aptManager";
 import Button from "@/components/atoms/Button/button";
@@ -131,17 +132,27 @@ export const columns: ColumnDef<AptManagerEntity>[] = [
   {
     header: "Data de Criação",
     accessorKey: "createdAt",
-    cell: ({ row }) =>
-      row.original.createdAt
-        ? row.original.createdAt.toDate().toLocaleDateString()
-        : "Não disponível"
+    cell: ({ row }) => {
+      const createdAt = row.original.createdAt;
+      const date =
+        createdAt instanceof Timestamp
+          ? createdAt.toDate()
+          : new Date(createdAt);
+      return createdAt ? date.toLocaleDateString() : "Não disponível";
+    }
   },
   {
     header: "Data de Bloqueio",
     accessorKey: "blockedAt",
-    cell: ({ row }) =>
-      row.original.blockedAt
-        ? row.original.blockedAt.toDate().toLocaleDateString()
-        : "Não bloqueado"
+    cell: ({ row }) => {
+      const blockedAt = row.original.blockedAt;
+      const date =
+        blockedAt instanceof Timestamp
+          ? blockedAt.toDate()
+          : blockedAt
+            ? new Date(blockedAt)
+            : null;
+      return date ? date.toLocaleDateString() : "Não bloqueado";
+    }
   }
 ];

--- a/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
+++ b/src/app/admin/condominios/ver-mais/[condoId]/components/AdminHistory/Columns.tsx
@@ -55,7 +55,6 @@ const GetStatus = ({ data }: { data: AptManagerEntity }) => {
       const nextStatus =
         curStatus === Status.ACTIVE ? Status.INACTIVE : Status.ACTIVE;
       const blockedAt = nextStatus === Status.INACTIVE ? Timestamp.now() : null;
-      setOptimisticStatus(nextStatus);
       await updateFirestoreDoc<AptManagerEntity>({
         documentPath: `/users/${data.id}`,
         data: {
@@ -68,6 +67,7 @@ const GetStatus = ({ data }: { data: AptManagerEntity }) => {
       } else {
         await activateUserAuth(data.id);
       }
+      setOptimisticStatus(nextStatus);
       await queryClient.invalidateQueries(["users", data.id]);
       successToast("Status do administrador atualizado com sucesso");
     } catch (error) {

--- a/src/app/admin/nova-empresa/page.tsx
+++ b/src/app/admin/nova-empresa/page.tsx
@@ -232,7 +232,12 @@ const NewCompany = () => {
 
       await setFirestoreDoc<AptManagerEntity>({
         docPath: `users/${aptManagerId}`,
-        data: { ...aptManagerData, image: imageUrl }
+        data: {
+          ...aptManagerData,
+          image: imageUrl,
+          createdAt: Timestamp.now(),
+          blockedAt: null
+        }
       });
 
       const companyData = {

--- a/src/common/entities/aptManager.ts
+++ b/src/common/entities/aptManager.ts
@@ -1,3 +1,5 @@
+import { Timestamp } from "firebase/firestore";
+
 import { AddressFields } from "./adressFields";
 import { MaritalStatusOptionsType } from "./common/maritalStatusOptionsType";
 
@@ -22,4 +24,6 @@ export interface AptManagerEntity extends AddressFields {
   adminRole: string;
   maritalStatus: MaritalStatusOptionsType;
   status: Status;
+  createdAt: Timestamp;
+  blockedAt: Timestamp | null;
 }

--- a/src/common/entities/aptManager.ts
+++ b/src/common/entities/aptManager.ts
@@ -5,8 +5,7 @@ import { MaritalStatusOptionsType } from "./common/maritalStatusOptionsType";
 
 export enum Status {
   ACTIVE = "ativo",
-  INACTIVE = "inativo",
-  UNDEFINED = "indefinido"
+  INACTIVE = "inativo"
 }
 
 export interface AptManagerEntity extends AddressFields {


### PR DESCRIPTION
## Added date columns to Admin's Columns component:

- createdAt
- blockedAt
	
## Fixed GetStatus function:

- Block date now appears when someone's status turns Inactive
- Loading is faster and 
- New "Loading" warning shows the user that Status is changing

## Added "GetStatus" changes to newAdminColumns component:

- Now, manager's table has "createdAt" and "blockedAt" columns with new features (like Columns component)

## How to Test:

- In terminal:

git checkout main
git pull
git checkout `<feature/columns-date-get-status>`
git pull origin `<feature/columns-date-get-status>`
pnpm install
pnpm dev

- In browser, go to http://localhost:3000/.

-First, check the manager's table:

Log in as the manager
Go to registration screen
Choose admin's section
Check the new dates features 
Check the new GetStatus features

-Then, check the admin's table:

Log in as the admin
Choose one condominium
Verify admin's history
Check the new dates features 
Check the new GetStatus features


