### PR TITLE
bugfix([fix/occurrencesTable]): implement disable pagination functionality

### DIFF
--- a/src/app/(authenticated)/sindico/historico/components/Incidents/Incidents.tsx
+++ b/src/app/(authenticated)/sindico/historico/components/Incidents/Incidents.tsx
@@ -3,7 +3,6 @@
 
 import { useState } from "react";
 
-import { useReactTable, getCoreRowModel } from "@tanstack/react-table";
 import Image from "next/image";
 import { twMerge } from "tailwind-merge";
 
@@ -48,17 +47,6 @@ const IncidentsTable = () => {
   );
 
   const { data: condo } = useCondo(condoId as string);
-
-  const tableInstance = useReactTable({
-    data: filteredData ?? [],
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-    initialState: {
-      pagination: {
-        pageSize: Infinity
-      }
-    }
-  });
 
   if (!condoId) return null;
 
@@ -123,7 +111,7 @@ const IncidentsTable = () => {
           <DataPaginatedTable<OccurrenceColumnData>
             data={filteredData ?? []}
             columns={columns}
-            optionalTable={tableInstance}
+            disablePagination={true}
           />
         </div>
       </div>

--- a/src/components/atoms/DataTablePaginated/DataTablePaginated.tsx
+++ b/src/components/atoms/DataTablePaginated/DataTablePaginated.tsx
@@ -23,20 +23,24 @@ import {
 export function DataPaginatedTable<T>({
   data,
   columns,
-  optionalTable
+  optionalTable,
+  disablePagination = false
 }: {
   data: T[];
   columns: ColumnDef<T, any>[];
   optionalTable?: TableType<T>;
+  disablePagination?: boolean;
 }) {
   const basicTableData = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
+    getPaginationRowModel: disablePagination
+      ? undefined
+      : getPaginationRowModel(),
     initialState: {
       pagination: {
-        pageSize: 6
+        pageSize: disablePagination ? Infinity : 6
       }
     }
   });
@@ -153,7 +157,7 @@ export function DataPaginatedTable<T>({
           )}
         </div>
       </div>
-      {totalPages > 1 && (
+      {!disablePagination && totalPages > 1 && (
         <div className="flex items-center justify-center space-x-2 px-2">
           <button
             className="h-4 w-4 transition-all hover:scale-[103%] disabled:cursor-not-allowed disabled:opacity-30"


### PR DESCRIPTION
## What I did
- Added pagination control via new disablePagination prop to DataPaginatedTable component

- Configured occurrences table to display all items on a single page

- Ensured existing paginated tables remain unaffected (backward compatibility)

- Improved print layout styling for full data visibility

### How to test
Run the application:


* git checkout bugfix/occurrencesTable  
* pnpm install && pnpm dev  

Verify in the browser (http://localhost:3000/):

All occurrences appear on a single page (no pagination buttons)
Clicking "Imprimir" shows complete table in print preview
Other tables in the system still show pagination normally
Layout adapts correctly to mobile/desktop screens

## Review changes:

- Check DataPaginatedTable component updates

- Verify IncidentsTable implementation