### PR TITLE
Hotfix/validatelostfound

### DIFF
--- a/src/app/(authenticated)/sindico/historico/components/LostAndFound/components/ValidateDeliverLostFound/ValidateDeliverLostFound.tsx
+++ b/src/app/(authenticated)/sindico/historico/components/LostAndFound/components/ValidateDeliverLostFound/ValidateDeliverLostFound.tsx
@@ -13,7 +13,7 @@ import SelectField from "@/components/molecules/SelectField/selectField";
 import useCondo from "@/hooks/queries/condos/useCondo";
 import useResidentsByCondoId from "@/hooks/queries/residents/useResidentsByCondoId";
 import useProfile from "@/hooks/queries/useProfile";
-import { successToast, errorToast } from "@/hooks/useAppToast";
+import { errorToast, successToast } from "@/hooks/useAppToast";
 import useAuth from "@/hooks/useAuth";
 import { queryClient } from "@/store/providers/queryClient";
 import { updateFirestoreDoc } from "@/store/services";
@@ -104,7 +104,7 @@ const ValidateDeliverLostFound = ({
       if (resident.deliveryCode) {
         setDeliveryCode(resident.deliveryCode);
       }
-      setDeliveredUserId(resident.id);
+      setDeliveredUserId(selectedResidentUid);
       setDeliveredUserName(resident.name);
     }
     setModalOpen(true);

--- a/src/app/(authenticated)/sindico/historico/components/LostAndFound/components/ValidateDeliverLostFound/ValidateDeliverLostFound.tsx
+++ b/src/app/(authenticated)/sindico/historico/components/LostAndFound/components/ValidateDeliverLostFound/ValidateDeliverLostFound.tsx
@@ -5,13 +5,14 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { inputClassName } from "@/app/contants";
+import { ResidentEntity } from "@/common/entities/resident";
 import AuthEnterModal from "@/components/atoms/AuthEnterModal/AuthEnterModal";
 import Button from "@/components/atoms/Button/button";
 import TransitionModal from "@/components/atoms/TransitionModal/tempModal";
 import SelectField from "@/components/molecules/SelectField/selectField";
 import useCondo from "@/hooks/queries/condos/useCondo";
-import useResidentsByUserData from "@/hooks/queries/residents/useResidentByUserData";
 import useResidentsByCondoId from "@/hooks/queries/residents/useResidentsByCondoId";
+import useProfile from "@/hooks/queries/useProfile";
 import { successToast, errorToast } from "@/hooks/useAppToast";
 import useAuth from "@/hooks/useAuth";
 import { queryClient } from "@/store/providers/queryClient";
@@ -88,22 +89,23 @@ const ValidateDeliverLostFound = ({
       )
       ?.map((item) => ({
         label: item.name,
-        value: item.name
+        value: item.name,
+        uid: item.id
       })) ?? [];
 
-  const { data: chosenResidentData } = useResidentsByUserData(
-    watch("formation"),
-    watch("apartment"),
-    watch("resident")
-  );
+  const selectedResidentUid =
+    residentsOptions.find((resident) => resident.value === watch("resident"))
+      ?.uid || "";
+
+  const { data: resident } = useProfile<ResidentEntity>(selectedResidentUid);
 
   const handleForm = async () => {
-    if (chosenResidentData && chosenResidentData.length > 0) {
-      if (chosenResidentData[0].deliveryCode) {
-        setDeliveryCode(chosenResidentData[0].deliveryCode);
+    if (resident) {
+      if (resident.deliveryCode) {
+        setDeliveryCode(resident.deliveryCode);
       }
-      setDeliveredUserId(chosenResidentData[0].id);
-      setDeliveredUserName(chosenResidentData[0].name);
+      setDeliveredUserId(resident.id);
+      setDeliveredUserName(resident.name);
     }
     setModalOpen(true);
   };


### PR DESCRIPTION
#What I did

- Replaced useResidentsByUserData with useProfile in the ValidateDeliverLostFound component
- Adjusted logic to handle the new structure returned by useProfile
- Removed unnecessary logic and improved overall readability

#How to test

- Open your terminal and navigate to the project's folder
- Run the following commands:

1. git checkout main
2. git pull
3. git checkout hotfix/validatelostfound
4. git pull origin hotfix/validatelostfound
5. pnpm install
6. pnpm dev

Open the project in your preferred code editor (e.g., code .)

In your browser, go to http://localhost:3000

Navigate to the Lost and Found admin flow and test the Delivery Validation feature

Confirm that:

- The list of residents loads correctly from the new hook
- The validation flow works as expected
- There are no errors or unexpected behavior in the UI or console
- Check the changed files section on GitHub to understand the scope of the refactor

Feel free to test any other related areas that might be affected by this change