### PR TITLE
bugfix(managerCreation): Updates default aptManagerData statuses to active

### DIFF
--- a/src/app/(authenticated)/sindico/cadastros/administration/components/createAdmin.tsx
+++ b/src/app/(authenticated)/sindico/cadastros/administration/components/createAdmin.tsx
@@ -176,7 +176,7 @@ export default function CreateAdminModal({
         number: data.ownerAddressData.number,
         cep: unmask(data.ownerAddressData.cep),
         city: data.ownerAddressData.city,
-        status: Status.INACTIVE,
+        status: Status.ACTIVE,
         createdAt: Timestamp.now(),
         blockedAt: null
       };

--- a/src/app/admin/nova-empresa/page.tsx
+++ b/src/app/admin/nova-empresa/page.tsx
@@ -230,7 +230,7 @@ const NewCompany = () => {
         cep: unmask(data.ownerAddressData.cep),
         city: data.ownerAddressData.city,
         adminRole: data.ownerBasicInfo.adminRole,
-        status: Status.INACTIVE
+        status: Status.ACTIVE
       };
 
       await setFirestoreDoc<AptManagerEntity>({


### PR DESCRIPTION
## What I did

- Updated the default `status` of `aptManagerData` to `Status.ACTIVE` in the following files:
  - `src/app/admin/nova-empresa/page.tsx`
  - `src/app/(authenticated)/sindico/cadastros/administration/components/createAdmin.tsx`

## How to test

1. Open the terminal and go to the folder of this project.

1. In the terminal:
   1. `git checkout main`
   1. `git pull`
   1. `git checkout bugfix/managerCreation`
   1. `git pull origin bugfix/managerCreation`
   1. `pnpm install`
   1. `code .`
   1. `pnpm dev`

1. In your browser, go to http://localhost:3000.

1. Test the following scenarios:
   - Create a new company and ensure the apartment manager's `status` is set to `ACTIVE` in the database.
   - Create a new administrator and verify that the `status` is set to `ACTIVE`.
   - Update an existing administrator and ensure the `status` remains consistent.

1. Read the changed files section on GitHub.

1. Test any other scenarios you think are worth testing, even those not explicitly mentioned in this description.